### PR TITLE
Add copyrights in LiteDocumentSerializer

### DIFF
--- a/miller/api/serializers.py
+++ b/miller/api/serializers.py
@@ -141,7 +141,7 @@ class LiteDocumentSerializer(serializers.ModelSerializer):
   attachment = OptionalFileField()
   class Meta:
     model = Document
-    fields = ('id', 'title', 'slug', 'mimetype', 'type', 'data', 'url', 'attachment', 'snapshot')
+    fields = ('id', 'title', 'slug', 'mimetype', 'type', 'data', 'url', 'attachment', 'snapshot', 'copyrights')
 
 
 


### PR DESCRIPTION
Add copyrights in LiteDocumentSerializer to be able to display them under pictures on the website