### PR TITLE
Populate meta tag on home page

### DIFF
--- a/miller/settings.py
+++ b/miller/settings.py
@@ -446,6 +446,7 @@ MILLER_DEBUG = True
 
 MILLER_TITLE = 'Miller'
 MILLER_DESCRIPTION = 'Developed by the University of Luxembourg'
+MILLER_KEYWORDS = 'miller,miller project'
 MILLER_SIGNEDBY = u'Miller Editorial Team\n'
 
 MILLER_LOCALE = os.path.join(BASE_DIR, 'client/src/locale/locale-all.csv')

--- a/miller/views.py
+++ b/miller/views.py
@@ -26,6 +26,7 @@ def _share(request=None, extra={}):
   d = {
     'title': settings.MILLER_TITLE,
     'description': settings.MILLER_DESCRIPTION,
+    'keywords': settings.MILLER_KEYWORDS,
     'debug': settings.MILLER_DEBUG,
     'settings': json.dumps(settings.MILLER_SETTINGS),
     'oembeds': json.dumps(settings.MILLER_OEMBEDS)
@@ -63,8 +64,7 @@ def _loadlocale():
 # views here
 @ensure_csrf_cookie
 def home(request):
-  return render(request, "miller/index.html")
-  #, _share(request))
+  return render(request, "miller/index.html", _share(request))
 
 def timelinejs(request, gsid):
   return render(request, "miller/timelinejs.iframe.html", {


### PR DESCRIPTION
Make the home view use the _share object as context (mainly to pass the meta description and keywords to the template) and add MILLER_KEYWORDS in settings.